### PR TITLE
Update pom.xml to address security-vuln

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   	<dependency>
   		<groupId>com.fasterxml.jackson.core</groupId>
   		<artifactId>jackson-databind</artifactId>
-  		<version>2.2.3</version>
+  		<version>2.8.11.1</version>
   	</dependency>
   	<dependency>
   		<groupId>log4j</groupId>


### PR DESCRIPTION
Github auto-opened an alert, "Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.8.11.1 or later" and referenced the following known-vulns:
* CVE-2017-17485
* CVE-2018-7489
* CVE-2017-7525
The alert suggested upgrading the library to v2.8.11.1 or greater.

Coming from v2.2.3, it is assumed there are no breaking-changes but I no longer actively maintain this codebase and so I have not validated this is true. I am only making this change in order to prevent known high-risk security vuln's to continue to exist in the wild; PLEASE TEST THOROUGHLY PRIOR TO USING THIS change.